### PR TITLE
Fix handlers repo defaults and add import test

### DIFF
--- a/src/ticketwatcher/handlers.py
+++ b/src/ticketwatcher/handlers.py
@@ -26,7 +26,7 @@ ALLOWED_PATHS  = [p.strip() for p in os.getenv("ALLOWED_PATHS", "").split(",") i
 MAX_FILES      = int(os.getenv("MAX_FILES", "4"))
 MAX_LINES      = int(os.getenv("MAX_LINES", "200"))
 AROUND_LINES   = int(os.getenv("DEFAULT_AROUND_LINES", "60"))
-REPO_ROOT = os.getenv("GITHUB_WORKSPACE")
+REPO_ROOT = os.getenv("GITHUB_WORKSPACE") or os.getcwd()
 REPO_NAME = (os.getenv("GITHUB_REPOSITORY") or "").split("/", 1)[-1] or os.path.basename(REPO_ROOT)
 
 # ----------------------------------------------------
@@ -38,8 +38,6 @@ def _mk_branch(issue_number: int) -> str:
 
 # ---------- seed parsing & snippet fetch ----------
 
-REPO_ROOT = os.getenv("GITHUB_WORKSPACE") or os.getcwd()
-REPO_NAME = (os.getenv("GITHUB_REPOSITORY") or "").split("/", 1)[-1] or os.path.basename(REPO_ROOT)
 
 _RE_PY_FILELINE = re.compile(r'File\s+"([^"]+)"\s*,\s*line\s+(\d+)\b')
 _RE_GENERIC_PATHLINE = re.compile(r'([^\s\'",)\]]+):(\d+)\b')  # token:line

--- a/test/test_ticketwatcher_handlers_import.py
+++ b/test/test_ticketwatcher_handlers_import.py
@@ -1,0 +1,45 @@
+import importlib
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+SRC = Path(__file__).resolve().parents[1] / "src"
+if str(SRC) not in sys.path:
+    sys.path.append(str(SRC))
+
+
+def test_handlers_import_without_repo_env(monkeypatch):
+    """Ensure handlers module loads without GitHub repo env vars."""
+
+    monkeypatch.delenv("GITHUB_WORKSPACE", raising=False)
+    monkeypatch.delenv("GITHUB_REPOSITORY", raising=False)
+
+    sys.modules.pop("ticketwatcher.handlers", None)
+
+    stub_github_api = ModuleType("ticketwatcher.github_api")
+    stub_github_api.get_default_branch = lambda: "main"
+    stub_github_api.create_branch = lambda *a, **k: None
+    stub_github_api.create_or_update_file = lambda *a, **k: None
+    stub_github_api.create_pr = lambda *a, **k: ("https://example.com", 1)
+    stub_github_api.get_file_text = lambda *a, **k: ""
+    stub_github_api.file_exists = lambda *a, **k: False
+    stub_github_api.add_issue_comment = lambda *a, **k: None
+    monkeypatch.setitem(sys.modules, "ticketwatcher.github_api", stub_github_api)
+
+    stub_agent_llm = ModuleType("ticketwatcher.agent_llm")
+
+    class _DummyAgent:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def run_two_rounds(self, *args, **kwargs):
+            return {"action": "request_context", "needs": [], "notes": ""}
+
+    stub_agent_llm.TicketWatcherAgent = _DummyAgent
+    monkeypatch.setitem(sys.modules, "ticketwatcher.agent_llm", stub_agent_llm)
+
+    module = importlib.import_module("ticketwatcher.handlers")
+
+    assert hasattr(module, "REPO_ROOT")
+    assert hasattr(module, "REPO_NAME")


### PR DESCRIPTION
## Summary
- ensure `ticketwatcher.handlers` derives the repo root and name once with a fallback to the current working directory
- add a smoke test that stubs external dependencies and confirms the handlers module imports when GitHub env vars are absent

## Testing
- pytest test/test_ticketwatcher_handlers_import.py

------
https://chatgpt.com/codex/tasks/task_e_68d8dd803aec83259ad1650b6b12bcdb