### PR TITLE
Refactor TicketWatcher handlers and fix auth utilities

### DIFF
--- a/docs/ticketwatcher_review.md
+++ b/docs/ticketwatcher_review.md
@@ -1,0 +1,41 @@
+# TicketWatcher Workflow Review
+
+## Overview
+TicketWatcher aims to ingest issue context, fetch relevant code snippets, and drive an automated fix loop via `TicketWatcherAgent`. The current implementation works end-to-end for narrow cases but exhibits fragility across configuration, module boundaries, and prompting. This document records key findings while debugging recent workflow failures and proposes incremental improvements.
+
+## Configuration & Path Allow-Listing
+* **Default allow-list is too restrictive.** Both the handler seed extraction and the agent share the `ALLOWED_PATHS` list, which resolves to `['src/', 'app/']` when the environment variable is unset.【F:src/ticketwatcher/handlers.py†L21-L31】【F:src/ticketwatcher/agent_llm.py†L32-L64】 Stack traces that reference files in `test/`, `scripts/`, or the worker package are silently ignored, so the agent never sees the failing code. Consider one of:
+  * Treating an empty environment variable as "allow everything" by default, only opting into narrow scopes when explicitly configured.
+  * Expanding the default list to include `test/`, `scripts/`, and `ticketwatcher-worker/`, or dynamically whitelisting prefixes observed in the incoming stack trace.
+  * Surfacing a warning when the seed extractor discards paths due to the allow-list, so debugging misconfiguration is easier.
+
+* **Agent request sanitization inherits the same limitation.** `_sanitize_needs` discards the model's follow-up requests if the path falls outside the allow-list.【F:src/ticketwatcher/agent_llm.py†L118-L154】 Without a looser default, the agent cannot recover by asking for the missing file later.
+
+## Module Structure
+`handlers.py` currently mixes six major responsibilities: configuration loading, stack-trace parsing, snippet fetching, diff parsing/apply logic, and GitHub mutation orchestration. At ~430 lines, it is challenging to test piecemeal. Splitting it into focused modules would reduce cognitive load and enable unit tests for each layer. Suggested decomposition:
+
+1. `config.py` – encapsulate environment parsing (`ALLOWED_PATHS`, limits, repo metadata) and expose a dataclass used throughout the workflow.
+2. `stack_parser.py` – own `_sanitize_path_token`, `_to_repo_relative`, and `parse_stack_text`. Provide explicit hooks for injecting extra allow-list prefixes per event.
+3. `snippets.py` – contain `_fetch_slice` and `_fetch_symbol_slice`, parameterized by a storage adapter (so GitHub can be mocked in tests).
+4. `diffs.py` – handle `_parse_unified_diff`, `_apply_hunks_to_text`, `_diff_stats`, and expose a safe `apply_patch` helper that validates file existence.
+5. `workflow.py` – orchestrate the end-to-end flow currently in `handle_issue_event`, keeping GitHub side effects in one place.
+
+Breaking these pieces apart would clarify responsibilities, simplify mocking during tests, and remove duplicated `import os` statements observed today.【F:src/ticketwatcher/handlers.py†L1-L18】
+
+## Prompt & Interaction Flow
+* The system prompt gives thorough JSON contract instructions, but the user prompt omits repo metadata that can help the model reason about unfamiliar directories (e.g., top-level packages, worker folder). Including a short "Repo structure" section summarizing the allowed prefixes or key modules could improve grounding for multi-package repositories.【F:src/ticketwatcher/agent_llm.py†L68-L116】
+* `run_two_rounds` currently performs at most two iterations: an initial call plus one follow-up after fetching requested snippets.【F:src/ticketwatcher/agent_llm.py†L90-L116】 If the model still needs context, the workflow exits with a canned comment. Allowing a configurable number of rounds (e.g., 3) or short-circuiting when the model repeatedly asks for the same files would make the workflow more resilient.
+* When the model returns malformed JSON, the agent silently converts it into an empty `request_context`. Logging or surfacing the truncated raw response would aid debugging prompt failures.【F:src/ticketwatcher/agent_llm.py†L128-L149】
+
+## Error Handling & Observability
+* `_apply_unified_diff` ignores missing files (the explicit guard is commented out). Reinstating this check prevents confusing "file not found" runtime errors when the model fabricates paths.【F:src/ticketwatcher/handlers.py†L266-L313】
+* Adding structured logging (or GitHub issue comments) when stack traces fail to yield any snippets would highlight when the agent is running blind.
+* Consider persisting intermediate artifacts (prompts, LLM responses, fetched snippets) as workflow run attachments; this dramatically shortens the loop when diagnosing failures like the `ModuleNotFoundError` reproduced earlier.
+
+## Next Steps
+1. Relax the default path restrictions so traces referencing tests or worker code seed useful snippets immediately.
+2. Extract stack parsing and diff application into standalone modules with unit tests, shrinking `handlers.py` and encouraging reuse.
+3. Enhance prompts with minimal repo context and allow an additional iteration in `run_two_rounds` to reduce "need more context" dead-ends.
+4. Restore guardrails in `_apply_unified_diff` and add logging around discarded paths and malformed responses for better observability.
+
+Implementing these steps should make TicketWatcher more reliable across heterogeneous repositories while keeping the workflow understandable and maintainable.

--- a/src/app/auth.py
+++ b/src/app/auth.py
@@ -1,14 +1,29 @@
+"""Authentication helpers."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
 from .user_repo import load_user
 from .utils.stringy import sanitize_string
 
-def get_user_profile(user_id: int | None):
-    """
-    Bug #1: crashes when user_id is None (should return {}).
-    Bug #2 (cross-file): depends on sanitize_string in another file.
-    """
-    # BUG: no guard for None
-    user = load_user(user_id)  # may return {} or None-ish fields
-    # BUG: no defaults; will KeyError or TypeError on missing keys/None
+
+def _normalize_user(record: Dict[str, Any] | None) -> Dict[str, Any]:
+    if not record:
+        return {"name": "", "email": ""}
+    return {"name": record.get("name", ""), "email": record.get("email", "")}
+
+
+def get_user_profile(user_id: int | None) -> Dict[str, str]:
+    """Return a sanitized profile dictionary or ``{}`` when unavailable."""
+    if user_id is None:
+        return {}
+
+    user = _normalize_user(load_user(user_id))
     name = sanitize_string(user["name"])
     email = sanitize_string(user["email"])
+
+    if not name and not email:
+        return {}
+
     return {"id": user_id, "name": name, "email": email}

--- a/src/app/utils/__init__.py
+++ b/src/app/utils/__init__.py
@@ -1,0 +1,4 @@
+"""Utility helpers for the app package."""
+from .stringy import sanitize_string  # noqa: F401
+
+__all__ = ["sanitize_string"]

--- a/src/app/utils/string.py
+++ b/src/app/utils/string.py
@@ -1,6 +1,0 @@
-def sanitize_string(s):
-    """
-    Bug #4: crashes on None; should return "" (empty) for None.
-    """
-    # BUG: assumes s is str
-    return s.strip()

--- a/src/app/utils/stringy.py
+++ b/src/app/utils/stringy.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def sanitize_string(value: Any) -> str:
+    """Trim whitespace from strings while tolerating ``None`` and non-strings."""
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value.strip()
+    return str(value).strip()

--- a/src/ticketwatcher/agent_llm.py
+++ b/src/ticketwatcher/agent_llm.py
@@ -5,6 +5,8 @@ from string import Template
 from typing import List, Dict, Any, Optional, Tuple
 from openai import OpenAI
 
+from .paths import allows_all_paths, is_path_allowed, parse_allowed_paths_env
+
 
 class TicketWatcherAgent:
     """
@@ -46,7 +48,7 @@ class TicketWatcherAgent:
         if allowed_paths is None:
             # Honor explicit []/ [""] inputs from callers by only falling back to
             # environment parsing when the argument is None.
-            self.allowed_paths = self._parse_allowed_paths_env(env_string)
+            self.allowed_paths = parse_allowed_paths_env(env_string)
         else:
             # Copy to avoid accidental mutation and preserve an explicit [] which
             # now signifies "allow everything".
@@ -277,27 +279,11 @@ OUTPUT MUST BE A SINGLE JSON OBJECT ONLY.
             return False
         if self._allows_all_paths():
             return True
-        return any(path.startswith(pfx) for pfx in self.allowed_paths)
+        return is_path_allowed(path, self.allowed_paths)
 
     def _allows_all_paths(self) -> bool:
         """True when the agent is configured without path restrictions."""
-        return (not self.allowed_paths) or ("" in self.allowed_paths)
-
-    @staticmethod
-    def _parse_allowed_paths_env(s: str) -> List[str]:
-        raw_parts = [(p or "").strip() for p in (s or "").split(",")]
-        allow_all = any(p == "" for p in raw_parts)
-
-        parts = [p for p in raw_parts if p]
-        # normalize to end with slash where appropriate
-        norm = []
-        for p in parts:
-            norm.append(p if p.endswith("/") else (p + ("/" if "." not in p else "")))
-
-        if not norm:
-            # An explicit empty entry (or a completely empty env var) means allow all.
-            return [""] if allow_all else ["src/"]
-        return norm
+        return allows_all_paths(self.allowed_paths)
 
     def _format_allowed_paths_for_prompt(self) -> str:
         if self._allows_all_paths():

--- a/src/ticketwatcher/config.py
+++ b/src/ticketwatcher/config.py
@@ -1,0 +1,51 @@
+"""Configuration loading for TicketWatcher."""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import List, Set
+
+from .paths import parse_allowed_paths_env
+
+
+@dataclass(frozen=True)
+class TicketWatcherConfig:
+    trigger_labels: Set[str]
+    branch_prefix: str
+    pr_title_prefix: str
+    allowed_paths: List[str]
+    max_files: int
+    max_lines: int
+    around_lines: int
+    repo_root: str
+    repo_name: str
+
+
+DEFAULT_ALLOWED = "src/,app/"
+
+
+def _resolve_repo_root() -> str:
+    return os.getenv("GITHUB_WORKSPACE") or os.getcwd()
+
+
+def _resolve_repo_name(repo_root: str) -> str:
+    repo_env = os.getenv("GITHUB_REPOSITORY")
+    if repo_env:
+        return repo_env.split("/", 1)[-1]
+    return os.path.basename(repo_root)
+
+
+def load_config() -> TicketWatcherConfig:
+    repo_root = _resolve_repo_root()
+    return TicketWatcherConfig(
+        trigger_labels=set(os.getenv("TICKETWATCHER_TRIGGER_LABELS", "agent-fix,auto-pr").split(",")),
+        branch_prefix=os.getenv("TICKETWATCHER_BRANCH_PREFIX", "agent-fix/"),
+        pr_title_prefix=os.getenv("TICKETWATCHER_PR_TITLE_PREFIX", "agent: auto-fix for issue"),
+        allowed_paths=parse_allowed_paths_env(os.getenv("ALLOWED_PATHS", DEFAULT_ALLOWED)),
+        max_files=int(os.getenv("MAX_FILES", "4")),
+        max_lines=int(os.getenv("MAX_LINES", "200")),
+        around_lines=int(os.getenv("DEFAULT_AROUND_LINES", "60")),
+        repo_root=repo_root,
+        repo_name=_resolve_repo_name(repo_root),
+    )
+

--- a/src/ticketwatcher/diff_utils.py
+++ b/src/ticketwatcher/diff_utils.py
@@ -1,0 +1,112 @@
+"""Lightweight helpers for diff parsing and application."""
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, Iterable, List, Tuple
+
+from .github_api import get_file_text
+from .paths import is_path_allowed
+
+_HUNK_RE = re.compile(r'^@@ -(\d+),?(\d+)? \+(\d+),?(\d+)? @@')
+
+
+def parse_unified_diff(diff_text: str) -> Dict[str, List[Dict[str, Any]]]:
+    files: Dict[str, List[Dict[str, Any]]] = {}
+    lines = diff_text.splitlines()
+    index = 0
+    current_file: str | None = None
+
+    while index < len(lines):
+        line = lines[index]
+        if line.startswith('--- a/'):
+            if index + 1 < len(lines) and lines[index + 1].startswith('+++ b/'):
+                current_file = lines[index + 1][6:]
+                files.setdefault(current_file, [])
+                index += 2
+                continue
+
+        match = _HUNK_RE.match(line)
+        if match and current_file:
+            old_start = int(match.group(1))
+            old_len = int(match.group(2) or "1")
+            new_start = int(match.group(3))
+            new_len = int(match.group(4) or "1")
+            hunk: Dict[str, Any] = {
+                "old_start": old_start,
+                "old_len": old_len,
+                "new_start": new_start,
+                "new_len": new_len,
+                "lines": [],
+            }
+            files[current_file].append(hunk)
+            index += 1
+            while index < len(lines) and not lines[index].startswith('@@') and not lines[index].startswith('--- a/'):
+                hunk["lines"].append(lines[index])
+                index += 1
+            continue
+
+        index += 1
+
+    return files
+
+
+def apply_hunks_to_text(original: str, hunks: List[Dict[str, Any]]) -> str:
+    source = original.splitlines()
+    output: List[str] = []
+    cursor = 1
+
+    for hunk in hunks:
+        old_start = hunk["old_start"]
+        while cursor < old_start:
+            output.append(source[cursor - 1])
+            cursor += 1
+
+        for line in hunk["lines"]:
+            if line.startswith(' '):
+                output.append(line[1:])
+                cursor += 1
+            elif line.startswith('-'):
+                cursor += 1
+            elif line.startswith('+'):
+                output.append(line[1:])
+            else:
+                output.append(line)
+                cursor += 1
+
+    while cursor <= len(source):
+        output.append(source[cursor - 1])
+        cursor += 1
+
+    return "\n".join(output)
+
+
+def apply_unified_diff(
+    *,
+    base_ref: str,
+    diff_text: str,
+    allowed_prefixes: Iterable[str] | None,
+) -> Dict[str, str]:
+    parsed = parse_unified_diff(diff_text)
+    updated: Dict[str, str] = {}
+
+    for path, hunks in parsed.items():
+        if not is_path_allowed(path, allowed_prefixes):
+            raise ValueError(f"Path not allowed: {path}")
+        current = get_file_text(path, base_ref)
+        updated[path] = apply_hunks_to_text(current, hunks)
+
+    return updated
+
+
+def diff_stats(diff_text: str) -> Tuple[int, int]:
+    files: set[str] = set()
+    changes = 0
+    for line in diff_text.splitlines():
+        if line.startswith('+++ b/'):
+            files.add(line[6:])
+        elif line.startswith('+') and not line.startswith('+++'):
+            changes += 1
+        elif line.startswith('-') and not line.startswith('---'):
+            changes += 1
+    return len(files), changes
+

--- a/src/ticketwatcher/github_api.py
+++ b/src/ticketwatcher/github_api.py
@@ -7,12 +7,22 @@ from typing import Optional, Dict, Any
 GITHUB_API = os.getenv("GITHUB_API", "https://api.github.com")
 # In GitHub Actions, this token is auto-injected with repo-scoped perms.
 TOKEN = os.getenv("GITHUB_TOKEN") or os.getenv("GH_TOKEN")
-REPO = os.getenv("GITHUB_REPOSITORY") or os.getenv("GITHUB_REPO")  # e.g. "owner/name"
 
-if not REPO:
-    raise RuntimeError("GITHUB_REPOSITORY or GITHUB_REPO not set")
 
-OWNER, NAME = REPO.split("/", 1)
+def _resolve_repo() -> tuple[str, str]:
+    repo = (
+        os.getenv("GITHUB_REPOSITORY")
+        or os.getenv("GITHUB_REPO")
+        or os.getenv("TICKETWATCHER_REPO")
+        or "local/local"
+    )
+    if "/" not in repo:
+        return "local", repo
+    owner, name = repo.split("/", 1)
+    return owner or "local", name or "local"
+
+
+OWNER, NAME = _resolve_repo()
 
 def _session() -> requests.Session:
     if not TOKEN:

--- a/src/ticketwatcher/handlers.py
+++ b/src/ticketwatcher/handlers.py
@@ -1,413 +1,154 @@
+"""Event handlers orchestrating the TicketWatcher workflow."""
 from __future__ import annotations
-import os
-import re
-import json
-import os, re
-from typing import List, Tuple, Iterable, Dict, Any
 
+import os
+from typing import Any, Dict, List
+
+from .agent_llm import TicketWatcherAgent
+from .config import load_config
+from .diff_utils import apply_unified_diff, diff_stats
 from .github_api import (
-    get_default_branch,
+    add_issue_comment,
     create_branch,
     create_or_update_file,
     create_pr,
-    get_file_text,
-    file_exists,              # add this small helper in github_api if you don’t have it yet
-    add_issue_comment,         # optional but nice to have
+    get_default_branch,
 )
-
-from .agent_llm import TicketWatcherAgent  # the class we just finished
-
-
-# --------- config knobs (can be env driven) ---------
-TRIGGER_LABELS = set(os.getenv("TICKETWATCHER_TRIGGER_LABELS", "agent-fix,auto-pr").split(","))
-BRANCH_PREFIX  = os.getenv("TICKETWATCHER_BRANCH_PREFIX", "agent-fix/")
-PR_TITLE_PREF  = os.getenv("TICKETWATCHER_PR_TITLE_PREFIX", "agent: auto-fix for issue")
-# Allowed path prefixes forwarded to the agent. [] or [""] means "no restrictions".
-def _load_allowed_paths() -> List[str]:
-    raw = os.getenv("ALLOWED_PATHS")
-    if raw is None:
-        return TicketWatcherAgent._parse_allowed_paths_env("src/,app/")
-    return TicketWatcherAgent._parse_allowed_paths_env(raw)
+from .snippets import fetch_slice, fetch_symbol_slice
+from .stackparse import parse_stack_text
 
 
-ALLOWED_PATHS = _load_allowed_paths()
-MAX_FILES      = int(os.getenv("MAX_FILES", "4"))
-MAX_LINES      = int(os.getenv("MAX_LINES", "200"))
-AROUND_LINES   = int(os.getenv("DEFAULT_AROUND_LINES", "60"))
-REPO_ROOT = os.getenv("GITHUB_WORKSPACE") or os.getcwd()
-REPO_NAME = (os.getenv("GITHUB_REPOSITORY") or "").split("/", 1)[-1] or os.path.basename(REPO_ROOT)
-
-# ----------------------------------------------------
+CONFIG = load_config()
+TRIGGER_LABELS = CONFIG.trigger_labels
+BRANCH_PREFIX = CONFIG.branch_prefix
+PR_TITLE_PREF = CONFIG.pr_title_prefix
+ALLOWED_PATHS = CONFIG.allowed_paths
+MAX_FILES = CONFIG.max_files
+MAX_LINES = CONFIG.max_lines
+AROUND_LINES = CONFIG.around_lines
+REPO_ROOT = CONFIG.repo_root
+REPO_NAME = CONFIG.repo_name
 
 
 def _mk_branch(issue_number: int) -> str:
     return f"{BRANCH_PREFIX}{issue_number}"
 
 
-# ---------- seed parsing & snippet fetch ----------
+def _gather_seed_snippets(ticket_body: str, base_ref: str) -> List[Dict[str, Any]]:
+    seeds: List[Dict[str, Any]] = []
+    specs = parse_stack_text(
+        ticket_body,
+        repo_root=REPO_ROOT,
+        repo_name=REPO_NAME,
+        allowed_prefixes=ALLOWED_PATHS,
+        limit=5,
+    )
+    for path, line in specs:
+        snippet = fetch_slice(
+            path,
+            base_ref=base_ref,
+            center_line=line,
+            around_lines=AROUND_LINES,
+            allowed_prefixes=ALLOWED_PATHS,
+        )
+        if snippet:
+            seeds.append(snippet)
+    return seeds
 
 
-_RE_PY_FILELINE = re.compile(r'File\s+"([^"]+)"\s*,\s*line\s+(\d+)\b')
-_RE_GENERIC_PATHLINE = re.compile(r'([^\s\'",)\]]+):(\d+)\b')  # token:line
-_RE_TARGET = re.compile(r'^\s*Target:\s*(.+?)\s*$', re.MULTILINE)  # Target: path[ :line]
-
-def _sanitize_path_token(tok: str) -> str:
-    """Strip wrapping quotes/backticks and trailing punctuation."""
-    tok = (tok or "").strip()
-    tok = tok.strip('`"\'')
-
-    # drop trailing punctuation/junk that commonly follows paths in traces
-    tok = re.sub(r'[\'"\s,)\]>]+$', '', tok)
-    return tok
-
-def _to_repo_relative(path: str) -> str:
-    """Return a path relative to the repo root (e.g., 'src/app/auth.py')."""
-    p = (path or "").strip().replace("\\", "/")
-
-    # If it includes '<repo_name>/', trim up to that
-    needle = f"/{REPO_NAME}/"
-    if needle in p:
-        p = p.split(needle, 1)[1]
-
-    # If absolute and under the workspace, relativize
-    try:
-        rel = os.path.relpath(p, REPO_ROOT).replace("\\", "/")
-    except Exception:
-        rel = p
-
-    return rel.lstrip("./").lstrip("/")
-
-def _path_allowed_with(path: str, allowed_prefixes: Iterable[str] | None) -> bool:
-    """Allowlist check; if prefixes empty/None or contains '', allow all."""
-    if not allowed_prefixes or any(a == "" for a in allowed_prefixes):
-        return True
-    p = _to_repo_relative(path)  # ensure repo-relative
-    for a in allowed_prefixes:
-        if not a:
-            return True
-        a = a if a.endswith("/") else a + "/"
-        if p == a[:-1] or p.startswith(a):
-            return True
-    return False
-
-def _path_allowed(path: str) -> bool:
-    """Single-arg convenience using the global ALLOWED_PATHS."""
-    return _path_allowed_with(path, ALLOWED_PATHS)
-
-def parse_stack_text(
-    text: str,
-    *,
-    allowed_prefixes: Iterable[str] | None = None,
-    limit: int = 5,
-) -> List[Tuple[str, int | None]]:
-    """
-    Extract (repo-relative path, line|None) pairs from mixed stack/trace text.
-    Order-preserving, de-duplicated, capped by 'limit'.
-    """
-    out: List[Tuple[str, int | None]] = []
-
-    if not text:
-        return out
-    #print(f'text{text}')
-    lines = text.splitlines()
-
-    # 1) Python "File "...", line N"
-    for line in lines:
-        #print(f'line:{line}')
-        m = _RE_PY_FILELINE.search(line)
-        if not m:
-            continue
-        raw = _sanitize_path_token(m.group(1))
-        path = _to_repo_relative(raw)
-        line_no = int(m.group(2))
-        if path and _path_allowed(path):
-            out.append((path, line_no))
-    #print(f'out1{out}')
-    # 2) Generic "token:LINE"
-    for line in lines:
-        for m in _RE_GENERIC_PATHLINE.finditer(line):
-            raw = _sanitize_path_token(m.group(1))
-            path = _to_repo_relative(raw)
-            line_no = int(m.group(2))
-            if path and _path_allowed(path):
-                out.append((path, line_no))
-
-    # 3) "Target: path" (optional ":line" allowed)
-    for m in _RE_TARGET.finditer(text):
-        raw_full = _sanitize_path_token(m.group(1))
-        # if someone wrote "Target: path:123", capture the line too
-        if ":" in raw_full and raw_full.rsplit(":", 1)[-1].isdigit():
-            raw_path, raw_line = raw_full.rsplit(":", 1)
-            line_no = int(raw_line)
-        else:
-            raw_path, line_no = raw_full, None
-        path = _to_repo_relative(raw_path)
-        if path and _path_allowed(path):
-            out.append((path, line_no))
-
-    # 4) De-dupe while preserving order, then cap
-    seen: set[Tuple[str, int]] = set()
-    uniq: List[Tuple[str, int | None]] = []
-
-    for p, ln in out:
-        key = (p, ln or 0)
-        if key in seen:
-            continue
-        seen.add(key)
-        uniq.append((p, ln))
-        #print(f'uniq{uniq}')
-        if len(uniq) >= max(1, limit):
-            break
-
-    return uniq
-
-
-def _fetch_slice(path: str, base: str, center_line: int | None, around: int) -> Dict[str, Any] | None:
-    """Fetch ±around lines for a file (centered at center_line if given)."""
-    if not _path_allowed(path) or not file_exists(path, base):
-        return None
-    content = get_file_text(path, base)
-    lines = content.splitlines()
-    n = len(lines)
-    if center_line is None or center_line < 1 or center_line > n:
-        # whole file is too big; return head slice
-        start = 1
-        end = min(n, 2 * around)
-    else:
-        start = max(1, center_line - around)
-        end = min(n, center_line + around)
-    code = "\n".join(lines[start - 1 : end])
-    return {"path": path, "start_line": start, "end_line": end, "code": code}
-
-
-def _fetch_symbol_slice(path: str, base: str, symbol: str, around: int) -> Dict[str, Any] | None:
-    """Naive symbol search to find a 'def <symbol>' or occurrence and slice around it."""
-    if not _path_allowed(path)or not file_exists(path, base):
-        return None
-    content = get_file_text(path, base)
-    lines = content.splitlines()
-    # Look for a definition first
-    def_pat = re.compile(rf'^\s*(def|class)\s+{re.escape(symbol)}\b')
-    idx = None
-    for i, line in enumerate(lines, start=1):
-        if def_pat.search(line):
-            idx = i
-            break
-    if idx is None:
-        # fallback: first occurrence
-        for i, line in enumerate(lines, start=1):
-            if symbol in line:
-                idx = i
-                break
-    if idx is None:
-        return None
-    start = max(1, idx - around)
-    end = min(len(lines), idx + around)
-    code = "\n".join(lines[start - 1 : end])
-    return {"path": path, "start_line": start, "end_line": end, "code": code}
-
-
-# ---------- unified diff parsing / application ----------
-
-_HUNK_RE = re.compile(r'^@@ -(\d+),?(\d+)? \+(\d+),?(\d+)? @@')
-
-def _parse_unified_diff(diff_text: str) -> Dict[str, List[Dict[str, Any]]]:
-    """
-    Parse a unified diff into a dict: { path: [ {old_start, old_len, new_start, new_len, lines: [...]}, ... ] }
-    Supports multi-file diffs for typical small patches.
-    """
-    files: Dict[str, List[Dict[str, Any]]] = {}
-    cur_file = None
-    cur_hunk = None
-    lines = diff_text.splitlines()
-    i = 0
-    while i < len(lines):
-        line = lines[i]
-        if line.startswith('--- a/'):
-            # next line should be +++ b/<path>
-            if i + 1 < len(lines) and lines[i + 1].startswith('+++ b/'):
-                path = lines[i + 1][6:]
-                cur_file = path
-                files.setdefault(cur_file, [])
-                i += 2
-                continue
-        m = _HUNK_RE.match(line)
-        if m and cur_file:
-            old_start = int(m.group(1))
-            old_len   = int(m.group(2) or "1")
-            new_start = int(m.group(3))
-            new_len   = int(m.group(4) or "1")
-            cur_hunk = {"old_start": old_start, "old_len": old_len, "new_start": new_start, "new_len": new_len, "lines": []}
-            files[cur_file].append(cur_hunk)
-            i += 1
-            # collect hunk lines until next header/file
-            while i < len(lines) and not lines[i].startswith('@@') and not lines[i].startswith('--- a/'):
-                cur_hunk["lines"].append(lines[i])
-                i += 1
-            continue
-        i += 1
-    return files
-
-
-def _apply_hunks_to_text(orig_text: str, hunks: List[Dict[str, Any]]) -> str:
-    """
-    Very small, forgiving hunk applier for typical patches produced by the agent.
-    Assumes hunks are in ascending order and apply cleanly.
-    """
-    src = orig_text.splitlines()
-    dst = []
-    cursor = 1  # 1-based
-    for h in hunks:
-        old_start = h["old_start"]
-        # copy unchanged lines up to the hunk
-        while cursor < old_start:
-            dst.append(src[cursor - 1])
-            cursor += 1
-        # consume old_len lines from src while reading hunk ops
-        # build replacement block
-        for ln in h["lines"]:
-            if ln.startswith(' '):
-                # context line: must match src
-                dst.append(ln[1:])
-                cursor += 1
-            elif ln.startswith('-'):
-                # deletion: skip in dst, advance src
-                cursor += 1
-            elif ln.startswith('+'):
-                # addition: add to dst, do not advance src
-                dst.append(ln[1:])
+def _build_fetch_callback(base_ref: str):
+    def _fetch(needs: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        snippets: List[Dict[str, Any]] = []
+        for need in needs:
+            path = need.get("path", "")
+            around = int(need.get("around_lines") or AROUND_LINES)
+            if need.get("symbol"):
+                snippet = fetch_symbol_slice(
+                    path,
+                    base_ref=base_ref,
+                    symbol=need["symbol"],
+                    around_lines=around,
+                    allowed_prefixes=ALLOWED_PATHS,
+                )
             else:
-                # unknown marker, treat as context
-                dst.append(ln)
-                cursor += 1
-    # copy the rest
-    while cursor <= len(src):
-        dst.append(src[cursor - 1])
-        cursor += 1
-    return "\n".join(dst)
+                snippet = fetch_slice(
+                    path,
+                    base_ref=base_ref,
+                    center_line=need.get("line"),
+                    around_lines=around,
+                    allowed_prefixes=ALLOWED_PATHS,
+                )
+            if snippet:
+                snippets.append(snippet)
+        return snippets
 
+    return _fetch
 
-def _apply_unified_diff(base_ref: str, diff_text: str) -> Dict[str, str]:
-    """
-    Fetch current file contents from base_ref, apply hunks, return {path: updated_text}.
-    Rejects paths outside ALLOWED_PATHS.
-    """
-    parsed = _parse_unified_diff(diff_text)
-    updated: Dict[str, str] = {}
-    for path, hunks in parsed.items():
-        if not _path_allowed(path):
-            raise ValueError(f"Path not allowed: {path}")
-        # if not file_exists(path, base_ref):
-        #     raise ValueError(f"File does not exist on base: {path}")
-        current = get_file_text(path, base_ref)
-        new_text = _apply_hunks_to_text(current, hunks)
-        updated[path] = new_text
-    return updated
-
-
-def _diff_stats(diff_text: str) -> Tuple[int, int]:
-    """Return (files_touched, changed_lines)."""
-    files = set()
-    changes = 0
-    for ln in diff_text.splitlines():
-        if ln.startswith('--- a/'):
-            pass
-        elif ln.startswith('+++ b/'):
-            files.add(ln[6:])
-        elif ln.startswith('+') and not ln.startswith('+++'):
-            changes += 1
-        elif ln.startswith('-') and not ln.startswith('---'):
-            changes += 1
-    return (len(files), changes)
-
-
-# ---------- main handlers ----------
 
 def handle_issue_event(event: Dict[str, Any]) -> str | None:
     action = event.get("action")
-    issue  = event.get("issue") or {}
+    issue = event.get("issue") or {}
     number = issue.get("number")
-    labels = {l["name"] for l in issue.get("labels", [])}
+    labels = {label["name"] for label in issue.get("labels", [])}
 
-    # Trigger only for relevant events/labels
     if not (action in {"opened", "reopened"} or action == "labeled" or (labels & TRIGGER_LABELS)):
         return None
+
     if action == "labeled":
-        lab = (event.get("label") or {}).get("name")
-        if lab and lab not in TRIGGER_LABELS:
+        label_name = (event.get("label") or {}).get("name")
+        if label_name and label_name not in TRIGGER_LABELS:
             return None
 
     title = issue.get("title", "")
-    body  = issue.get("body", "") or ""
-    base  = os.getenv("TICKETWATCHER_BASE_BRANCH") or get_default_branch()
+    body = issue.get("body", "") or ""
+    base = os.getenv("TICKETWATCHER_BASE_BRANCH") or get_default_branch()
 
-    # 1) Build seed snippets from traceback/target hints
-    seed_specs = parse_stack_text(body, allowed_prefixes=ALLOWED_PATHS, limit=5)
-    seed_snips: List[Dict[str, Any]] = []
-    for path, line in seed_specs:
-        snip = _fetch_slice(path, base, line, AROUND_LINES)
-        if snip:
-            seed_snips.append(snip)
-    
-    # 2) Call agent (two-round loop)
+    seed_snippets = _gather_seed_snippets(body, base)
+
     agent = TicketWatcherAgent(
-        # Pass the prefixes through unchanged so the agent sees the same
-        # allow-all or allowlist semantics documented above.
         allowed_paths=ALLOWED_PATHS,
         max_files=MAX_FILES,
         max_total_lines=MAX_LINES,
         default_around_lines=AROUND_LINES,
     )
 
-    def _fetch_callback(needs: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-        results: List[Dict[str, Any]] = []
-        for n in needs:
-            path = n.get("path", "")
-            line = n.get("line")
-            symbol = n.get("symbol")
-            around = int(n.get("around_lines") or AROUND_LINES)
-            if symbol:
-                sn = _fetch_symbol_slice(path, base, symbol, around)
-            else:
-                sn = _fetch_slice(path, base, line, around)
-            if sn:
-                results.append(sn)
-        return results
+    fetch_callback = _build_fetch_callback(base)
+    result = agent.run_two_rounds(title, body, seed_snippets, fetch_callback=fetch_callback)
 
-    result = agent.run_two_rounds(title, body, seed_snips, fetch_callback=_fetch_callback)
-
-    # 3) If the agent asked for more (again), give guidance and stop
     if result.get("action") == "request_context":
-        add_issue_comment(number,
+        add_issue_comment(
+            number,
             "⚠️ I need more context to propose a safe fix. "
-            "Please include a traceback (`File \"src/...\", line N`) or add `Target: <path.py>`."
+            "Please include a traceback (`File \"src/...\", line N`) or add `Target: <path.py>`.",
         )
         return None
 
-    # 4) Validate diff against budgets/paths
     diff = result.get("diff", "")
-    files_touched, changed_lines = _diff_stats(diff)
+    files_touched, changed_lines = diff_stats(diff)
     if files_touched > MAX_FILES or changed_lines > MAX_LINES:
-        add_issue_comment(number,
+        add_issue_comment(
+            number,
             f"⚠️ Proposed change exceeds budgets (files={files_touched}, lines={changed_lines}). "
-            "Escalating to human review or try narrowing the scope."
+            "Escalating to human review or try narrowing the scope.",
         )
         return None
 
-    # 5) Apply diff -> updated file texts
     try:
-        updated_files = _apply_unified_diff(base, diff)
-    except Exception as e:
-        add_issue_comment(number, f"❌ Could not apply patch: {e}")
+        updated_files = apply_unified_diff(
+            base_ref=base,
+            diff_text=diff,
+            allowed_prefixes=ALLOWED_PATHS,
+        )
+    except Exception as exc:  # pylint: disable=broad-except
+        add_issue_comment(number, f"❌ Could not apply patch: {exc}")
         return None
 
-    # 6) Create branch, commit updates, open DRAFT PR
     branch = _mk_branch(number)
     create_branch(branch, base)
-    for path, text in updated_files.items():
+    for path, content in updated_files.items():
         create_or_update_file(
             path=path,
-            content_text=text,
+            content_text=content,
             message=f"agent: {title[:72]}",
             branch=branch,
         )
@@ -420,7 +161,6 @@ def handle_issue_event(event: Dict[str, Any]) -> str | None:
         draft=True,
     )
 
-     # Comment summary back on the PR (use PR number for /issues/{number}/comments)
     notes = result.get("notes", "")
     pr_comment = (
         f"✅ Draft PR opened: {pr_url}\n\n"
@@ -430,19 +170,15 @@ def handle_issue_event(event: Dict[str, Any]) -> str | None:
     )
     add_issue_comment(pr_number, pr_comment)
 
-    # (Optional) also notify the original issue if you want
     try:
         add_issue_comment(number, f"Draft PR opened: {pr_url}")
-    except Exception as e:
-        print(f"[warn] could not comment on issue #{number}: {e}")
+    except Exception as exc:  # pylint: disable=broad-except
+        print(f"[warn] could not comment on issue #{number}: {exc}")
 
     return pr_url
 
+
 def handle_issue_comment_event(event: Dict[str, Any]) -> str | None:
-    """
-    Optional: keep your '/agent fix' comment trigger. It now just runs the same agent path,
-    using the comment body as extra ticket context.
-    """
     action = event.get("action")
     if action != "created":
         return None
@@ -454,9 +190,9 @@ def handle_issue_comment_event(event: Dict[str, Any]) -> str | None:
     if not comment_body.strip().lower().startswith("/agent fix"):
         return None
 
-    # Reuse the main flow by pretending the comment text is appended to the body
     issue_copy = dict(issue)
     issue_copy["body"] = (issue.get("body") or "") + "\n\n" + comment_body
-    fake_event = dict(event)
-    fake_event["issue"] = issue_copy
-    return handle_issue_event(fake_event)
+    synthetic_event = dict(event)
+    synthetic_event["issue"] = issue_copy
+    return handle_issue_event(synthetic_event)
+

--- a/src/ticketwatcher/paths.py
+++ b/src/ticketwatcher/paths.py
@@ -1,0 +1,74 @@
+"""Shared helpers for working with repository paths and allowlists."""
+from __future__ import annotations
+
+import os
+from typing import Iterable, List
+
+
+def parse_allowed_paths_env(raw: str | None) -> List[str]:
+    """Parse a comma-separated env string into normalized allowlist prefixes."""
+    if raw is None:
+        return ["src/"]
+
+    raw_parts = [(part or "").strip() for part in raw.split(",")]
+    parts = [p for p in raw_parts if p]
+    allow_all = any(part == "" for part in raw_parts)
+
+    normalized: List[str] = []
+    for part in parts:
+        normalized.append(_normalize_prefix(part))
+
+    if not normalized:
+        # Only treat it as "allow everything" when the env var is explicitly empty.
+        return [""] if allow_all else ["src/"]
+
+    if allow_all and "" not in normalized:
+        normalized.append("")
+
+    return normalized
+
+
+def _normalize_prefix(prefix: str) -> str:
+    """Ensure directory-like prefixes end with a slash for cheap prefix checks."""
+    if not prefix:
+        return ""
+    if prefix.endswith("/"):
+        return prefix
+    # If the last path component looks like a filename (contains a dot), keep as-is.
+    tail = prefix.split("/")[-1]
+    return prefix if "." in tail else prefix + "/"
+
+
+def allows_all_paths(prefixes: Iterable[str] | None) -> bool:
+    """Return True when the allowlist permits touching any path."""
+    if not prefixes:
+        return True
+    return any(prefix == "" for prefix in prefixes)
+
+
+def is_path_allowed(path: str, prefixes: Iterable[str] | None) -> bool:
+    """Simple prefix-based allowlist check for repo-relative paths."""
+    if not path:
+        return False
+    if allows_all_paths(prefixes):
+        return True
+    return any(path == prefix.rstrip("/") or path.startswith(prefix) for prefix in prefixes or [])
+
+
+def to_repo_relative(path: str, repo_root: str, repo_name: str) -> str:
+    """Convert an absolute path to repo-relative form when possible."""
+    cleaned = (path or "").strip().replace("\\", "/")
+    if not cleaned:
+        return ""
+
+    repo_token = f"/{repo_name}/" if repo_name else None
+    if repo_token and repo_token in cleaned:
+        cleaned = cleaned.split(repo_token, 1)[1]
+
+    try:
+        rel = os.path.relpath(cleaned, repo_root).replace("\\", "/")
+    except Exception:
+        rel = cleaned
+
+    return rel.lstrip("./").lstrip("/")
+

--- a/src/ticketwatcher/paths.py
+++ b/src/ticketwatcher/paths.py
@@ -10,20 +10,19 @@ def parse_allowed_paths_env(raw: str | None) -> List[str]:
     if raw is None:
         return ["src/"]
 
-    raw_parts = [(part or "").strip() for part in raw.split(",")]
-    parts = [p for p in raw_parts if p]
-    allow_all = any(part == "" for part in raw_parts)
+    if raw.strip() == "":
+        return [""]
 
     normalized: List[str] = []
-    for part in parts:
-        normalized.append(_normalize_prefix(part))
+    for part in raw.split(","):
+        trimmed = (part or "").strip()
+        if not trimmed:
+            continue
+        normalized.append(_normalize_prefix(trimmed))
 
     if not normalized:
-        # Only treat it as "allow everything" when the env var is explicitly empty.
-        return [""] if allow_all else ["src/"]
-
-    if allow_all and "" not in normalized:
-        normalized.append("")
+        # A string that only contained commas or whitespace still means "allow all".
+        return [""]
 
     return normalized
 

--- a/src/ticketwatcher/snippets.py
+++ b/src/ticketwatcher/snippets.py
@@ -1,0 +1,81 @@
+"""Helpers for fetching contextual code snippets from the repository."""
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, Iterable, List
+
+from .github_api import file_exists, get_file_text
+from .paths import is_path_allowed
+
+
+def fetch_slice(
+    path: str,
+    *,
+    base_ref: str,
+    center_line: int | None,
+    around_lines: int,
+    allowed_prefixes: Iterable[str] | None,
+) -> Dict[str, Any] | None:
+    if not is_path_allowed(path, allowed_prefixes) or not file_exists(path, base_ref):
+        return None
+
+    content = get_file_text(path, base_ref)
+    lines = content.splitlines()
+    total = len(lines)
+
+    if center_line is None or center_line < 1 or center_line > total:
+        start = 1
+        end = min(total, 2 * around_lines)
+    else:
+        start = max(1, center_line - around_lines)
+        end = min(total, center_line + around_lines)
+
+    return {
+        "path": path,
+        "start_line": start,
+        "end_line": end,
+        "code": "\n".join(lines[start - 1 : end]),
+    }
+
+
+def fetch_symbol_slice(
+    path: str,
+    *,
+    base_ref: str,
+    symbol: str,
+    around_lines: int,
+    allowed_prefixes: Iterable[str] | None,
+) -> Dict[str, Any] | None:
+    if not symbol:
+        return None
+    if not is_path_allowed(path, allowed_prefixes) or not file_exists(path, base_ref):
+        return None
+
+    content = get_file_text(path, base_ref)
+    lines = content.splitlines()
+    definition_pattern = re.compile(rf'^\s*(def|class)\s+{re.escape(symbol)}\b')
+
+    target_line = None
+    for index, line in enumerate(lines, start=1):
+        if definition_pattern.search(line):
+            target_line = index
+            break
+
+    if target_line is None:
+        for index, line in enumerate(lines, start=1):
+            if symbol in line:
+                target_line = index
+                break
+
+    if target_line is None:
+        return None
+
+    start = max(1, target_line - around_lines)
+    end = min(len(lines), target_line + around_lines)
+    return {
+        "path": path,
+        "start_line": start,
+        "end_line": end,
+        "code": "\n".join(lines[start - 1 : end]),
+    }
+

--- a/src/ticketwatcher/stackparse.py
+++ b/src/ticketwatcher/stackparse.py
@@ -1,0 +1,71 @@
+"""Utilities for extracting useful paths from issue descriptions and traces."""
+from __future__ import annotations
+
+import re
+from typing import Iterable, List, Tuple
+
+from .paths import is_path_allowed, to_repo_relative
+
+_RE_PY_FILELINE = re.compile(r'File\s+"([^"]+)"\s*,\s*line\s+(\d+)\b')
+_RE_GENERIC_PATHLINE = re.compile(r'([^\s\'",)\]]+):(\d+)\b')
+_RE_TARGET = re.compile(r'^\s*Target:\s*(.+?)\s*$', re.MULTILINE)
+
+
+def _sanitize_path_token(token: str) -> str:
+    token = (token or "").strip()
+    token = token.strip('`"\'')
+    return re.sub(r'[\'"\s,)\]>]+$', "", token)
+
+
+def parse_stack_text(
+    text: str,
+    *,
+    repo_root: str,
+    repo_name: str,
+    allowed_prefixes: Iterable[str] | None = None,
+    limit: int = 5,
+) -> List[Tuple[str, int | None]]:
+    """Return repo-relative path/line pairs extracted from stack-like text."""
+    results: List[Tuple[str, int | None]] = []
+    if not text:
+        return results
+
+    lines = text.splitlines()
+
+    def _record(raw_path: str, line_no: int | None) -> None:
+        path = to_repo_relative(raw_path, repo_root, repo_name)
+        if path and is_path_allowed(path, allowed_prefixes):
+            results.append((path, line_no))
+
+    for line in lines:
+        match = _RE_PY_FILELINE.search(line)
+        if not match:
+            continue
+        _record(match.group(1), int(match.group(2)))
+
+    for line in lines:
+        for match in _RE_GENERIC_PATHLINE.finditer(line):
+            _record(match.group(1), int(match.group(2)))
+
+    for match in _RE_TARGET.finditer(text):
+        raw_full = _sanitize_path_token(match.group(1))
+        if ":" in raw_full and raw_full.rsplit(":", 1)[-1].isdigit():
+            raw_path, raw_line = raw_full.rsplit(":", 1)
+            line_no = int(raw_line)
+        else:
+            raw_path, line_no = raw_full, None
+        _record(raw_path, line_no)
+
+    deduped: List[Tuple[str, int | None]] = []
+    seen: set[Tuple[str, int]] = set()
+    for path, line_no in results:
+        key = (path, line_no or 0)
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append((path, line_no))
+        if len(deduped) >= max(1, limit):
+            break
+
+    return deduped
+

--- a/test/test_paths_allowed.py
+++ b/test/test_paths_allowed.py
@@ -1,0 +1,23 @@
+import pytest
+
+from ticketwatcher.paths import parse_allowed_paths_env
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        (None, ["src/"]),
+        ("", [""]),
+        ("   ", [""]),
+        ("src/,app/,", ["src/", "app/"]),
+        ("src/app.py,lib", ["src/app.py", "lib/"]),
+    ],
+)
+def test_parse_allowed_paths_env(raw, expected, monkeypatch):
+    # Ensure environment has no influence; the helper only uses the provided raw string.
+    monkeypatch.delenv("ALLOWED_PATHS", raising=False)
+    assert parse_allowed_paths_env(raw) == expected
+
+
+def test_empty_entries_only_allow_all():
+    assert parse_allowed_paths_env(",,,") == [""]


### PR DESCRIPTION
## Summary
- refactor the TicketWatcher workflow into modular utilities for configuration, stack parsing, snippet fetching, and diff application while aligning allowed-path semantics with the agent
- update handlers, the agent wrapper, and GitHub API helper to use the shared utilities and tolerate missing GitHub repository metadata when running locally
- harden the auth helper and sanitizer so None and missing fields are handled gracefully and expose the utils package for imports

## Testing
- PYTHONPATH=src pytest test/test_utils_sanitize.py test/test_auth_trims.py test/test_auth_none_user.py


------
https://chatgpt.com/codex/tasks/task_e_68d8dc5c99d4832583f7dbe07916d097